### PR TITLE
 Tiny update: Pre no longer required for distorm3 install

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -646,7 +646,7 @@ vim"
 
 install_ubuntu_12.04_pip_packages() {
     pip_packages="rekall docopt python-evtx python-registry six construct pyv8 pefile"
-    pip_pre_packages="distorm3 bitstring"
+    pip_pre_packages="bitstring"
 
     if [ "$@" = "dev" ]; then
         pip_packages="$pip_packages"


### PR DESCRIPTION
In a GRR install [issue](https://github.com/google/grr/issues/36) elsewhere on GitHub, @brifordwylie chased down the distorm3 author and got that fixed upstream so that we don't have to tiptoe around it in pip, yay.