### PR TITLE
Include unity-control-center for high-DPI screens

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -542,6 +542,7 @@ tcptrace
 tofrodos
 torsocks
 transmission
+unity-control-center
 unrar
 upx-ucl
 vbindiff


### PR DESCRIPTION
Closes sans-dfir/sift#58, at least for the bootstrap.sh file. Note this will still need to be fixed in deployed SIFT versions.

Yes, I accidentally made a pull request against my own fork before doing this. I blame a lack of sufficient sleep and caffeine.