### PR TITLE
Make more robust homedir expansion

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -847,24 +847,24 @@ configure_ubuntu_sift_vm() {
 	fi
 
   echoinfo "SIFT VM: Setting up useful links on $SUDO_USER Desktop"
-	if [ ! -L /home/$SUDO_USER/Desktop/cases ]; then
-		sudo -u $SUDO_USER ln -s /cases /home/$SUDO_USER/Desktop/cases
+	if [ ! -L ~$SUDO_USER/Desktop/cases ]; then
+		sudo -u $SUDO_USER ln -s /cases ~$SUDO_USER/Desktop/cases
 	fi
   
-	if [ ! -L /home/$SUDO_USER/Desktop/mount_points ]; then
-		sudo -u $SUDO_USER ln -s /mnt /home/$SUDO_USER/Desktop/mount_points
+	if [ ! -L ~$SUDO_USER/Desktop/mount_points ]; then
+		sudo -u $SUDO_USER ln -s /mnt ~$SUDO_USER/Desktop/mount_points
 	fi
 
   echoinfo "SIFT VM: Cleaning up broken symlinks on $SUDO_USER Desktop"
 	# Clean up broken symlinks
-	find -L /home/$SUDO_USER/Desktop -type l -delete
+	find -L ~$SUDO_USER/Desktop -type l -delete
 
   echoinfo "SIFT VM: Adding all SIFT Resources to $SUDO_USER Desktop"
 	for file in /usr/share/sift/resources/*.pdf
 	do
 		base=`basename $file`
-		if [ ! -L /home/$SUDO_USER/Desktop/$base ]; then
-			sudo -u $SUDO_USER ln -s $file /home/$SUDO_USER/Desktop/$base
+		if [ ! -L ~$SUDO_USER/Desktop/$base ]; then
+			sudo -u $SUDO_USER ln -s $file ~$SUDO_USER/Desktop/$base
 		fi
 	done
 
@@ -891,13 +891,13 @@ configure_ubuntu_12.04_sift_vm() {
   # Works in 12.04 and 14.04
   sudo -u $SUDO_USER gsettings set org.gnome.desktop.background picture-uri file:///usr/share/sift/images/forensics_blue.jpg  >> $HOME/sift-install.log 2>&1
 
-	if [ ! -d /home/$SUDO_USER/.config/autostart ]; then
-		sudo -u $SUDO_USER mkdir -p /home/$SUDO_USER/.config/autostart
+	if [ ! -d ~$SUDO_USER/.config/autostart ]; then
+		sudo -u $SUDO_USER mkdir -p ~$SUDO_USER/.config/autostart
 	fi
 
   # Works in 14.04 too.
-	if [ ! -L /home/$SUDO_USER/.config/autostart ]; then
-		sudo -u $SUDO_USER cp /usr/share/sift/other/gnome-terminal.desktop /home/$SUDO_USER/.config/autostart
+	if [ ! -L ~$SUDO_USER/.config/autostart ]; then
+		sudo -u $SUDO_USER cp /usr/share/sift/other/gnome-terminal.desktop ~$SUDO_USER/.config/autostart
 	fi
     
     # Works in 14.04 too
@@ -909,7 +909,7 @@ configure_ubuntu_12.04_sift_vm() {
   # Works in 12.04 only
 	gsettings set com.canonical.unity-greeter background file:///usr/share/sift/images/forensics_blue.jpg >> $HOME/sift-install.log 2>&1
   
-  chown -R $SUDO_USER:$SUDO_USER /home/$SUDO_USER
+  chown -R $SUDO_USER:$SUDO_USER ~$SUDO_USER
 }
 
 # 14.04 SIFT VM Configuration Function
@@ -920,13 +920,13 @@ configure_ubuntu_14.04_sift_vm() {
   sudo -u $SUDO_USER gsettings set org.gnome.desktop.background picture-uri file:///usr/share/sift/images/forensics_blue.jpg >> $HOME/sift-install.log 2>&1
 
   # Works in 14.04 
-	if [ ! -d /home/$SUDO_USER/.config/autostart ]; then
-		sudo -u $SUDO_USER mkdir -p /home/$SUDO_USER/.config/autostart
+	if [ ! -d ~$SUDO_USER/.config/autostart ]; then
+		sudo -u $SUDO_USER mkdir -p ~$SUDO_USER/.config/autostart
 	fi
 
   # Works in 14.04 too.
-	if [ ! -L /home/$SUDO_USER/.config/autostart ]; then
-		sudo -u $SUDO_USER cp /usr/share/sift/other/gnome-terminal.desktop /home/$SUDO_USER/.config/autostart
+	if [ ! -L ~$SUDO_USER/.config/autostart ]; then
+		sudo -u $SUDO_USER cp /usr/share/sift/other/gnome-terminal.desktop ~$SUDO_USER/.config/autostart
 	fi
     
   # Works in 14.04 too
@@ -941,7 +941,7 @@ configure_ubuntu_14.04_sift_vm() {
   # Setup the login background image
   cp /usr/share/sift/images/forensics_blue.jpg /usr/share/backgrounds/warty-final-ubuntu.png
   
-  chown -R $SUDO_USER:$SUDO_USER /home/$SUDO_USER
+  chown -R $SUDO_USER:$SUDO_USER ~$SUDO_USER
 }
 
 complete_message() {

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -846,6 +846,11 @@ configure_ubuntu_sift_vm() {
 		echo "alias mountwin='mount -o ro,loop,show_sys_files,streams_interface=windows'" >> /root/.bash_aliases
 	fi
 
+  echoinfo "SIFT VM: Sanity check for Desktop folder"
+        if [ ! -d ~$SUDO_USER/Desktop ]; then
+                sudo -u $SUDO_USER mkdir -p ~$SUDO_USER/Desktop
+        fi
+  
   echoinfo "SIFT VM: Setting up useful links on $SUDO_USER Desktop"
 	if [ ! -L ~$SUDO_USER/Desktop/cases ]; then
 		sudo -u $SUDO_USER ln -s /cases ~$SUDO_USER/Desktop/cases


### PR DESCRIPTION
Home directories are sometimes in other directories than /home/, this fix assures correct homedir is taken by using ~USER shell expansion. 