### PR TITLE
add apparmor handler

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -298,6 +298,7 @@ libxml2-dev
 maltegoce
 mantaray
 md5deep
+nautilus-open-terminal
 nbd-client
 nbtscan
 netcat

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -128,6 +128,11 @@ __enable_docker_repository() {
   add-apt-repository -y "deb https://apt.dockerproject.org/repo ubuntu-$(lsb_release -sc) main"
 }
 
+__enable_bro_repository() {
+    wget -q -O /tmp/bro_apt.key http://download.opensuse.org/repositories/network:bro/xUbuntu_14.04/Release.key
+    apt-key add /tmp/bro_apt.key
+    echo "deb http://download.opensuse.org/repositories/network:/bro/xUbuntu_15.10/ /" >> /etc/apt/sources.list.d/bro.list
+}
 __check_unparsed_options() {
     shellopts="$1"
     # grep alternative for SunOS
@@ -174,6 +179,9 @@ install_ubuntu_14.04_deps() {
     echoinfo "Enabling Docker Repository ... "
     __enable_docker_repository >> $HOME/sift-install.log 2>&1 || return 1
 
+    echoinfo "Enabling Bro Repository ... "
+    __enable_bro_repository >> $HOME/sift-install.log 2>&1 || return 1
+
     echoinfo "Adding Ubuntu Tweak Repository"
     add-apt-repository -y ppa:tualatrix/ppa  >> $HOME/sift-install.log 2>&1 || return 1
 
@@ -207,6 +215,8 @@ bitpim-lib
 bkhive
 bless
 blt
+bro
+broctl
 build-essential
 bulk-extractor
 cabextract

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -360,6 +360,7 @@ tcl
 tcpflow
 tcpick
 tcpreplay
+tcpslice
 tcpstat
 tcptrace
 tcptrack

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -298,8 +298,6 @@ libxml2-dev
 maltegoce
 mantaray
 md5deep
-mongodb-clients
-mongodb-server
 nbd-client
 nbtscan
 netcat

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -198,6 +198,7 @@ afflib-tools
 afterglow
 aircrack-ng
 apache2
+apparmor-utils
 arp-scan
 autopsy
 bcrypt
@@ -442,6 +443,22 @@ install_ubuntu_14.04_pip_packages() {
     return 0
 }
 
+# fix apparmor profiles that cause really frustrating and hard to fix problems
+fix_apparmor_profiles() {
+    # list full path for each binary to diable (space-separated)
+    apparmor_disable_binaries="/usr/sbin/tcpdump"
+
+    for APPARMOR_BINARY in $apparmor_disable_binaries; do
+        CURRENT_ERROR=0
+        echoinfo "Disabling apparmor profile: $APPARMOR_BINARY"
+        aa-complain $APPARMOR_BINARY
+        if [ $CURRENT_ERROR -ne 0 ]; then
+            echoerror "Error disabling profile for $APPARMOR_BINARY"
+        fi
+    done
+
+    return 0
+}
 
 # Global: Works on 12.04 and 14.04
 install_perl_modules() {
@@ -768,6 +785,7 @@ if [ "$UPGRADE_ONLY" -eq 1 ]; then
   install_ubuntu_${VER}_packages $ITYPE || echoerror "Updating Packages Failed"
   install_ubuntu_${VER}_pip_packages $ITYPE || echoerror "Updating Python Packages Failed"
   install_perl_modules || echoerror "Updating Perl Packages Failed"
+  apparmor_disable_binaries || echoerror "Disabling AppArmor Profiles Failed"
   install_sift_files || echoerror "Installing/Updating SIFT Files Failed"
 
   echo ""
@@ -812,6 +830,7 @@ if [ "$INSTALL" -eq 1 ] && [ "$CONFIGURE_ONLY" -eq 0 ]; then
     install_ubuntu_${VER}_pip_packages $ITYPE
     configure_cpan
     install_perl_modules
+    apparmor_disable_binaries
     install_sift_files
 fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -174,10 +174,6 @@ install_ubuntu_14.04_deps() {
     echoinfo "Enabling Docker Repository ... "
     __enable_docker_repository >> $HOME/sift-install.log 2>&1 || return 1
 
-    echoinfo "Enabling Elastic Repository ... "
-    wget -qO - "https://packages.elasticsearch.org/GPG-KEY-elasticsearch" | apt-key add - >> $HOME/sift-install.log 2>&1 || return 1
-    add-apt-repository "deb http://packages.elasticsearch.org/elasticsearch/1.5/debian stable main" >> $HOME/sift-install.log 2>&1 || return 1
-
     echoinfo "Adding Ubuntu Tweak Repository"
     add-apt-repository -y ppa:tualatrix/ppa  >> $HOME/sift-install.log 2>&1 || return 1
 
@@ -227,7 +223,6 @@ driftnet
 dsniff
 dumbpig
 e2fslibs-dev
-elasticsearch
 ent
 epic5
 etherape
@@ -452,27 +447,6 @@ install_ubuntu_14.04_pip_packages() {
 install_perl_modules() {
 	# Required by macl.pl script
 	perl -MCPAN -e "install Net::Wigle" >> $HOME/sift-install.log 2>&1
-}
-
-install_kibana() {
-  CDIR=$(pwd)
-  cd /tmp
-  wget "https://download.elasticsearch.org/kibana/kibana/kibana-3.1.0.tar.gz"  >> $HOME/sift-install.log 2>&1
-  tar -zxf kibana-3.1.0.tar.gz  >> $HOME/sift-install.log 2>&1
-  cd /tmp/kibana-3.1.0/ >> $HOME/sift-install.log 2>&1
-  mkdir -p /var/www/html/kibana
-  cp -r . /var/www/html/kibana >> $HOME/sift-install.log 2>&1
-  cd $CDIR
-}
-
-configure_elasticsearch() {
-	if ! grep -i "http.cors.enabled" /etc/elasticsearch/elasticsearch.yml > /dev/null 2>&1
-	then
-		echo "http.cors.enabled: true" >> /etc/elasticsearch/elasticsearch.yml
-	fi
-
-  update-rc.d elasticsearch defaults 95 10 >> $HOME/sift-install.log 2>&1
-  service elasticsearch start  >> $HOME/sift-install.log 2>&1
 }
 
 install_sift_files() {
@@ -794,7 +768,6 @@ if [ "$UPGRADE_ONLY" -eq 1 ]; then
   install_ubuntu_${VER}_packages $ITYPE || echoerror "Updating Packages Failed"
   install_ubuntu_${VER}_pip_packages $ITYPE || echoerror "Updating Python Packages Failed"
   install_perl_modules || echoerror "Updating Perl Packages Failed"
-  install_kibana || echoerror "Installing/Updating Kibana Failed"
   install_sift_files || echoerror "Installing/Updating SIFT Files Failed"
 
   echo ""
@@ -839,11 +812,8 @@ if [ "$INSTALL" -eq 1 ] && [ "$CONFIGURE_ONLY" -eq 0 ]; then
     install_ubuntu_${VER}_pip_packages $ITYPE
     configure_cpan
     install_perl_modules
-    install_kibana
     install_sift_files
 fi
-
-configure_elasticsearch
 
 # Configure for SIFT
 configure_ubuntu


### PR DESCRIPTION
FRUSTRATING problem when trying to use tcpdump to read a file that doesn't end in .pcap - for example .pcap1 .pcap2 etc as with a rolling capture created using -C or -G flags.
tcpdump returns "permission denied" even though copy/hexdump/etc on the pcap1 file works fine.

problem is that /usr/sbin/tcpdump has an apparmor profile that restricts its behavior.  apparently using file extensions.  because of reasons.

This should fix it, but needs testing before merge.  to test, create a pcap file, rename it .pcap1 and try to tcpdump the file.  I was also unsure of how you'd want to do error handling (if at all - aa-complain seems to return 0 always).

See https://help.ubuntu.com/community/AppArmor and https://ubuntuforums.org/showthread.php?t=1501339
